### PR TITLE
Replace the `RefResolver` as it is now deprecated and causing warnings

### DIFF
--- a/.cookiecutter/includes/setuptools/install_requires
+++ b/.cookiecutter/includes/setuptools/install_requires
@@ -1,2 +1,3 @@
-jsonschema
+jsonschema>=4.18
 importlib_resources
+referencing

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,9 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     importlib_metadata;python_version<"3.8."
-    jsonschema
+    jsonschema>=4.18
     importlib_resources
+    referencing
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This is causing warnings to pop out in consumers of this library when they update to `json-schema>=4.18`:

 * https://github.com/python-jsonschema/jsonschema/blob/main/CHANGELOG.rst#v4180
 * https://python-jsonschema.readthedocs.io/en/stable/referencing/#resolving-references-from-the-file-system

This will unblock:

  * https://github.com/hypothesis/h/pull/8058