### PR TITLE
Fix CI

### DIFF
--- a/src/h_api/bulk_api/command_processor.py
+++ b/src/h_api/bulk_api/command_processor.py
@@ -1,4 +1,5 @@
 """Interface for processing batches of commands."""
+
 from collections import defaultdict
 
 from h_api.bulk_api.command_batcher import CommandBatcher

--- a/src/h_api/bulk_api/executor.py
+++ b/src/h_api/bulk_api/executor.py
@@ -1,4 +1,5 @@
 """Implementations of an 'Executor' responsible for running bulk commands."""
+
 from abc import ABC, abstractmethod
 
 from h_api.bulk_api.model.report import Report

--- a/src/h_api/bulk_api/observer.py
+++ b/src/h_api/bulk_api/observer.py
@@ -1,6 +1,5 @@
 """Implementations of an 'Observer' which is informed of commands."""
 
-
 import json
 
 from h_api.enums import CommandStatus

--- a/src/h_api/schema.py
+++ b/src/h_api/schema.py
@@ -1,6 +1,5 @@
 """Classes for loading and parsing JSON schema."""
 
-
 import json
 from functools import lru_cache
 

--- a/tests/unit/h_api/bulk_api/command_processor_test.py
+++ b/tests/unit/h_api/bulk_api/command_processor_test.py
@@ -166,7 +166,7 @@ class TestCommandProcessor:
 
         command_processor.process(commands)
 
-        assert command_processor.reports == Any.dict.containing(
+        assert command_processor.reports == Any.dict().containing(
             {DataType.USER: [Any.instance_of(Report)]}
         )
 

--- a/tests/unit/h_api/bulk_api/entry_point_test.py
+++ b/tests/unit/h_api/bulk_api/entry_point_test.py
@@ -92,9 +92,9 @@ class TestBulkAPI:
         (generator,), _ = CommandProcessor.return_value.process.call_args
 
         assert isinstance(generator, GeneratorType)
-        assert generator == Any.iterable.comprised_of(Any.instance_of(Command)).of_size(
-            4
-        )
+        assert generator == Any.iterable().comprised_of(
+            Any.instance_of(Command)
+        ).of_size(4)
 
     def _decode_ndjson(self, nd_json):
         return [json.loads(data) for data in nd_json.strip().split("\n")]

--- a/tests/unit/h_api/bulk_api/executor_test.py
+++ b/tests/unit/h_api/bulk_api/executor_test.py
@@ -28,5 +28,5 @@ class TestAutomaticReportExecutor:
             batch=[sentinel.command, sentinel.command, sentinel.command],
         )
 
-        assert results == Any.list.comprised_of(Any.instance_of(Report)).of_size(3)
+        assert results == Any.list().comprised_of(Any.instance_of(Report)).of_size(3)
         assert len({report.id for report in results}) == 3

--- a/tests/unit/h_api/bulk_api/functional_test.py
+++ b/tests/unit/h_api/bulk_api/functional_test.py
@@ -59,9 +59,9 @@ class TestBulkAPIFunctional:
 
         assert command_data == [
             ["configure", Any.dict()],
-            ["upsert", {"data": Any.dict.containing({"type": "user"})}],
-            ["upsert", {"data": Any.dict.containing({"type": "group"})}],
-            ["create", {"data": Any.dict.containing({"type": "group_membership"})}],
+            ["upsert", {"data": Any.dict().containing({"type": "user"})}],
+            ["upsert", {"data": Any.dict().containing({"type": "group"})}],
+            ["create", {"data": Any.dict().containing({"type": "group_membership"})}],
         ]
 
     def test_round_tripping(self, commands, collecting_observer):

--- a/tests/unit/h_api/schema_test.py
+++ b/tests/unit/h_api/schema_test.py
@@ -19,9 +19,9 @@ class TestValidator:
         assert isinstance(error, SchemaValidationError)
 
         assert [body.raw for body in error.error_bodies] == [
-            Any.dict.containing({"source": {"pointer": "a"}}),
-            Any.dict.containing(
-                {"meta": Any.dict.containing({"schema": {"pointer": "required"}})}
+            Any.dict().containing({"source": {"pointer": "a"}}),
+            Any.dict().containing(
+                {"meta": Any.dict().containing({"schema": {"pointer": "required"}})}
             ),
         ]
 


### PR DESCRIPTION
1. Run `make format` to update the formatting to the latest Black behavior

2. Tweak the code to avoid a couple of false-positive warnings that pylint has started emitting.

   Pylint is confused by the crazy stuff that `h-matchers`'s "fluent entrypoint" decorator does in order to enable `Any.list.containing(...)` instead of having to write `Any.list().containing(...)`.